### PR TITLE
Add module aliases

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/carbon
+lts/dubnium

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@blackbaud/skyux": "2.30.0",
-    "@blackbaud/skyux-builder": "1.29.0"
+    "@blackbaud/skyux": "2.42.0",
+    "@blackbaud/skyux-builder": "1.31.1"
   }
 }

--- a/skyuxconfig-schema.json
+++ b/skyuxconfig-schema.json
@@ -175,6 +175,10 @@
       ],
       "default": "easy"
     },
+    "moduleAliases": {
+      "description": "Specifies module aliases to allow for custom module resolution.",
+      "type": "object"
+    },
     "name": {
       "description": "Specifies the name of the project when running in SKY UX Host. By default, SKY UX Builder uses the name property in the package.json file, minus the 'blackbaud-skyux-spa-' prefix.",
       "type": "string"

--- a/src/app/public/config.ts
+++ b/src/app/public/config.ts
@@ -81,7 +81,7 @@ export interface SkyuxConfig {
   host?: SkyuxConfigHost;
   importPath?: string;
   mode?: string;
-  moduleAliases: {[key:string]: string};
+  moduleAliases: {[key: string]: string};
   name?: string;
   pacts?: any[];
   params?: SkyuxConfigParams; // List of allowed params

--- a/src/app/public/config.ts
+++ b/src/app/public/config.ts
@@ -81,6 +81,7 @@ export interface SkyuxConfig {
   host?: SkyuxConfigHost;
   importPath?: string;
   mode?: string;
+  moduleAliases: {[key:string]: string};
   name?: string;
   pacts?: any[];
   params?: SkyuxConfigParams; // List of allowed params


### PR DESCRIPTION
This would allow SPAs to provide their own module resolve aliases.
Webpack config: https://webpack.js.org/configuration/resolve/#resolvealias
Related Builder PR: https://github.com/blackbaud/skyux-builder/pull/517

**skyuxconfig.json**
```
{
  "moduleAliases": {
    "@skyux/core": "./src/app/public"
  }
}
```