### PR TITLE
Added useLocalCompilerOptions option to allow for the use of local compiler options from a project's tsconfig

### DIFF
--- a/src/app/public/config.ts
+++ b/src/app/public/config.ts
@@ -131,6 +131,7 @@ export interface SkyuxConfig {
   omnibar?: any;
   useHashRouting?: boolean;
   skyuxModules?: string[];
+  useLocalCompilerOptions?: boolean;
 }
 
 @Injectable()


### PR DESCRIPTION
This is related to https://github.com/blackbaud/skyux-sdk-builder/issues/251